### PR TITLE
test: 로그인 컴포넌트 유닛테스트 추가

### DIFF
--- a/src/test/login/InputField.test.tsx
+++ b/src/test/login/InputField.test.tsx
@@ -1,0 +1,56 @@
+import { screen, render } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+
+import InputField from '@/components/login/InputField';
+describe("InputField Component Test", () => {
+
+    test("should render with label and input field", () => {
+        render(<InputField id="username-input" label="사용자 이름" />);
+        const inputElement = screen.getByLabelText("사용자 이름");
+
+        const labelElement = screen.getByText("사용자 이름");
+
+        expect(inputElement).toBeInTheDocument();
+        expect(labelElement).toBeInTheDocument();
+
+        expect(inputElement).toHaveAttribute('type', 'text');
+    });
+
+    test("should render with the correct placeholder", () => {
+        const placeholderText = "이름을 입력하세요";
+        render(<InputField id="name-input" label="이름" placeholder={placeholderText} />);
+
+        const inputElement = screen.getByPlaceholderText(placeholderText);
+
+        expect(inputElement).toBeInTheDocument();
+        expect(inputElement).toHaveAttribute('placeholder', placeholderText);
+    });
+
+    test("should render with the specified type", () => {
+        render(<InputField id="password-input" label="비밀번호" type="password" />);
+
+        const inputElement = screen.getByLabelText("비밀번호");
+
+        expect(inputElement).toBeInTheDocument();
+        expect(inputElement).toHaveAttribute('type', 'password');
+    });
+
+    test("should render the rightElement when provided", () => {
+        const rightElementContent = <span>오른쪽 내용</span>;
+
+        render(<InputField id="extra-input" label="추가 정보" rightElement={rightElementContent} />);
+
+        const renderedRightElement = screen.getByText("오른쪽 내용");
+
+        expect(renderedRightElement).toBeInTheDocument();
+    });
+
+    test("should not render rightElement if not provided", () => {
+        render(<InputField id="simple-input" label="단순 입력" />);
+
+        const rightElementContent = screen.queryByText("오른쪽 내용");
+
+        expect(rightElementContent).not.toBeInTheDocument();
+    });
+
+});

--- a/src/test/login/LoginButton.test.tsx
+++ b/src/test/login/LoginButton.test.tsx
@@ -1,0 +1,26 @@
+import { screen, render, fireEvent } from "@testing-library/react";
+import { describe, test, expect, vi } from "vitest";
+import LoginButton from "@/components/login/LoginButton";
+
+describe("LoginButton Test", () => {
+    const buttonLabels = [
+        '로그인',
+        '회원가입',
+    ];
+    test.each(buttonLabels)("should render button with %s label", (label) => {
+        render(<LoginButton>{label}</LoginButton>);
+
+        const buttonElement = screen.getByText(label);
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).toBeInstanceOf(HTMLButtonElement);
+        expect(buttonElement).toHaveAttribute("type", "submit");
+    });
+    test("should call onClick when clicked", () => {
+        const handleClick = vi.fn();
+        render(<LoginButton onClick={handleClick}>로그인</LoginButton>)
+        const buttonLabel = screen.getByText("로그인");
+        fireEvent.click(buttonLabel);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    })
+})

--- a/src/test/login/LoginForm.test.tsx
+++ b/src/test/login/LoginForm.test.tsx
@@ -1,0 +1,19 @@
+import { screen, render } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import LoginForm from "@/components/login/LoginForm";
+
+describe('LoginForm Test', () => {
+    test("should render correctly with login form", () => {
+        render(<LoginForm />)
+
+        const buttonElement = screen.getByText('로그인');
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).toBeInstanceOf(HTMLButtonElement)
+        expect(buttonElement).toHaveAttribute('type', 'submit')
+
+        expect(screen.getByText("이메일")).toBeInTheDocument();
+        expect(screen.getByText("비밀번호")).toBeInTheDocument();
+        expect(screen.getByText("비밀번호 찾기")).toBeInTheDocument();
+    })
+})

--- a/src/test/login/LoginTabs.test.tsx
+++ b/src/test/login/LoginTabs.test.tsx
@@ -1,0 +1,53 @@
+
+import { screen, render, waitFor } from "@testing-library/react";
+import userEvent from '@testing-library/user-event';
+import { describe, test, expect, vi } from "vitest";
+import LoginTabs from "@/components/login/LoginTabs";
+
+vi.mock('@/components/login/LoginForm', () => ({
+    default: () => {
+        return <div>Mock Login Form</div>;
+    },
+}));
+
+vi.mock('@/components/login/RegisterForm', () => ({
+    default: () => {
+        return <div>Mock Register Form</div>;
+    },
+}));
+
+describe('Login Tabs Test', () => {
+    test('should render correctly with login tab active by default', async () => {
+        render(<LoginTabs />);
+
+        expect(screen.getByText('로그인')).toBeInTheDocument();
+        expect(screen.getByText('회원가입')).toBeInTheDocument();
+
+        await screen.findByText('Mock Login Form');
+
+        await waitFor(() => {
+            expect(screen.queryByText('Mock Register Form')).not.toBeInTheDocument();
+        });
+        const loginTabElement = screen.getByRole('tab', { name: '로그인' });
+        const registerTabElement = screen.getByRole('tab', { name: '회원가입' });
+        expect(loginTabElement).toHaveAttribute('data-state', 'active');
+        expect(registerTabElement).toHaveAttribute('data-state', 'inactive')
+    });
+
+    test("should render correctly with register tab when user click register tab", async () => {
+        render(<LoginTabs />);
+        const registerTabElement = screen.getByRole('tab', { name: '회원가입' });
+        const loginTabElement = screen.getByRole("tab", { name: '로그인' });
+
+        userEvent.click(registerTabElement);
+
+        await waitFor(() => {
+            expect(screen.getByText('Mock Register Form')).toBeInTheDocument();
+            expect(screen.queryByText('Mock Login Form')).not.toBeInTheDocument();
+        });
+
+        expect(loginTabElement).toHaveAttribute('data-state', 'inactive');
+        expect(registerTabElement).toHaveAttribute('data-state', 'active')
+
+    })
+});

--- a/src/test/login/RegisterForm.test.tsx
+++ b/src/test/login/RegisterForm.test.tsx
@@ -1,0 +1,22 @@
+import { screen, render } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import RegisterForm from "@/components/login/RegisterForm";
+
+describe('RegisterForm test', () => {
+    test("should render correctly with register form", () => {
+        render(<RegisterForm />)
+
+        const buttonElement = screen.getByText("회원가입");
+
+        expect(buttonElement).toBeInTheDocument();
+        expect(buttonElement).toBeInstanceOf(HTMLButtonElement);
+        expect(buttonElement).toHaveAttribute("type", "submit");
+
+        expect(screen.getByText("이름")).toBeInTheDocument()
+        expect(screen.getByText('이메일')).toBeInTheDocument()
+        expect(screen.getByText('비밀번호')).toBeInTheDocument()
+        expect(screen.getByText('비밀번호 확인')).toBeInTheDocument()
+        expect(screen.getByText('회원가입')).toBeInTheDocument()
+
+    })
+})


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #1 

## 🆕 기능 추가

- **기능 추가**:  로그인관련 컴포넌트에 대한 유닛 테스트 추가

## 🔍 테스트 사항

- 기본적으로 렌더링된 UI가 올바른 텍스트를 가지고 있는지 테스트
- 추후 로그인 로직이 추가되면 별개의 커스텀 훅 및 테스트 진행 예정
