### PR TITLE
Fix#20 이벤트 스트림의 마지막 값이 나오지 않는 현상

### DIFF
--- a/src/entities/message/ui/ChatMessageWrapper.tsx
+++ b/src/entities/message/ui/ChatMessageWrapper.tsx
@@ -1,6 +1,7 @@
 import { ChatMessageType } from "@/entities/message/types/chat-message-props"
 import { ChatMessage } from "./ChatMessage"
 import { ChatMessageLoading } from "./ChatMessageLoading"
+import { useEffect, useRef } from "react"
 
 interface ChatMessageWrapperProps {
     messages: ChatMessageType[]
@@ -8,18 +9,40 @@ interface ChatMessageWrapperProps {
 }
 
 const ChatMessageWrapper = ({ messages, isLoading }: ChatMessageWrapperProps) => {
+    const messageEndRef = useRef<HTMLDivElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (messageEndRef.current && containerRef.current) {
+            const container = containerRef.current;
+            const isAtBottom = container.scrollHeight - container.scrollTop <= container.clientHeight + 100;
+
+            if (isAtBottom) {
+                messageEndRef.current.scrollIntoView({
+                    behavior: "smooth",
+                    block: "end"
+                });
+            }
+        }
+    }, [messages.length]);
+
     return (
-        <div className="flex flex-col w-full p-4 space-y-4 overflow-y-auto">
-            {messages.map((message) => (
+        <div
+            ref={containerRef}
+            className="flex-1 flex flex-col w-full p-4 space-y-4 overflow-y-auto"
+        >
+            {messages.map((message, index) => (
                 <ChatMessage
-                    key={message.id}
+                    key={`${message.createdAt}-${index}`}
                     message={message.message}
                     sender={message.sender}
                     createdAt={message.createdAt}
                 />
             ))}
             {isLoading && <ChatMessageLoading />}
+            <div ref={messageEndRef} />
         </div>
     )
 }
+
 export default ChatMessageWrapper


### PR DESCRIPTION
## 🖇️ 연결 된 이슈

- #20 

## 📋 변경 사항

- complete  이벤트 시 상태 업데이트를 동기적으로 처리하도록 `flushSync` 사용
- 메시지 자동 스크롤 추가

## 📝 추가 사항

- `flushSync`의 경우 문제가 생길 수 있음
- 이후 똑같은 문제가 발생한다면 `messageQueue`를 만드는 식으로 시도해볼 예정